### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_install:
   - "sudo apt-get update"
   - "sudo apt-get install python-dev"
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock"
+  - "travis_retry pip install check-manifest mock"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -61,6 +61,7 @@ before_script:
   - "inveniomanage database create --quiet || echo ':('"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_cloudconnector --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_cloudconnector --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ requirements = [
 ]
 
 test_requirements = [
-    'pytest>=2.7.0',
-    'pytest-cov>=1.8.0',
+    'pytest>=2.8.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'coverage>=3.7.1',
+    'coverage>=4.0.0',
 ]
 
 
@@ -78,9 +78,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
